### PR TITLE
Use standard format for license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 The MIT License (MIT)
 
-Original code copyright (c) 2014-2019 Toby Zerner
-Modified code copyright (c) 2019 Jordan Schnaidt
-Synopsis copyright (c) 2020 Ian Morland
+Copyright (c) 2020 Ian Morland
+Copyright (c) 2019 Jordan Schnaidt
+Copyright (c) 2014-2019 Toby Zerner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This should fix license detection on GitHub.

Before:
![aebde566](https://user-images.githubusercontent.com/5972388/125204503-fbe7e480-e27d-11eb-903e-db4a7a0f86b0.png)

After:
![5d2f226f](https://user-images.githubusercontent.com/5972388/125204508-01452f00-e27e-11eb-9128-d72c8b73de5f.png)
