### PR TITLE
feat: make excerpt content non-interactive

### DIFF
--- a/js/src/forum/addSummaryExcerpt.js
+++ b/js/src/forum/addSummaryExcerpt.js
@@ -35,7 +35,7 @@ export default function addSummaryExcerpt() {
 
         if (excerptPost) {
             const excerpt = (
-                <div>
+                <div inert>
                     {richExcerpt ? m.trust(truncate(excerptPost.contentHtml(), excerptLength)) : truncate(excerptPost.contentPlain(), excerptLength)}
                 </div>
             );

--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -7,6 +7,10 @@
   color: @muted-more-color;
   display: block;
 
+  // Fallback for `inert` HTML attribute
+  // Prevents interactivity with items within the excerpt
+  pointer-events: none;
+
   img {
     max-width: 100%
   }


### PR DESCRIPTION
Prevents link/image clicks on synopsis from taking you to their respective locations when meaning to view the discussion instead.

While this doesn't directly affect synopsis as-is, if the excerpt is moved to another location, interactivity is allowed.

The `inert` attribute also tells accessibility engines that the content within is non-interactive.