### PR TITLE
fix: remove unneeded includes

### DIFF
--- a/js/src/forum/addSummaryExcerpt.js
+++ b/js/src/forum/addSummaryExcerpt.js
@@ -18,7 +18,8 @@ import { truncate } from 'flarum/common/utils/string';
 
 export default function addSummaryExcerpt() {
     extend(DiscussionListState.prototype, 'requestParams', function (params) {
-        params.include.push(['firstPost', 'lastPost']);
+        if (app.forum.attribute('synopsis.excerpt_type') === 'first') params.include.push('firstPost');
+        else params.include.push('lastPost');
     });
 
     extend(DiscussionListItem.prototype, 'infoItems', function (items) {


### PR DESCRIPTION
Only include the relationships that are needed.

On forums which use `firstPost` for synopsis, this saves from loading the `lastPost` relation entirely, and vice versa.