### PR TITLE
fix: various replaced element widths too wide

### DIFF
--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -18,6 +18,7 @@
   .DiscussionPage-list & {
     display: none;
   }
+
   @media @phone {
     display: none;
   }
@@ -32,7 +33,7 @@
   color: @muted-more-color;
   display: block;
 
-  img {
+  * {
     max-width: 100%
   }
 

--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -11,7 +11,7 @@
   // Prevents interactivity with items within the excerpt
   pointer-events: none;
 
-  img {
+  * {
     max-width: 100%
   }
 


### PR DESCRIPTION
Enforce max width on all excerpt contents.

This fixes issues such as embed iframes and videos being too wide for the excerpt container.