### PR TITLE
fix: it replaces most relevant post content when searching

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,8 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+[*.{js,ts,jsx,tsx,yml}]
+indent_size = 2
 [*.md]
 indent_size = 2
 trim_trailing_whitespace = false

--- a/extend.php
+++ b/extend.php
@@ -31,9 +31,11 @@ return [
         ->default('ianm-synopsis.excerpt_length', 200)
         ->default('ianm-synopsis.rich-excerpts', false)
         ->default('ianm-synopsis.excerpt-type', 'first')
+        ->default('ianm-synopsis.disable-when-searching', true)
         ->serializeToForum('synopsis.excerpt_length', 'ianm-synopsis.excerpt_length', 'intVal')
         ->serializeToForum('synopsis.rich_excerpts', 'ianm-synopsis.rich-excerpts', 'boolVal')
-        ->serializeToForum('synopsis.excerpt_type', 'ianm-synopsis.excerpt-type'),
+        ->serializeToForum('synopsis.excerpt_type', 'ianm-synopsis.excerpt-type')
+        ->serializeToForum('synopsis.disable_when_searching', 'ianm-synopsis.disable-when-searching', 'boolval'),
 
     (new Extend\ApiController(ListDiscussionsController::class))
         ->prepareDataForSerialization(LoadRelations::class),

--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -31,6 +31,12 @@ app.initializers.add('ianm-synopsis', () => {
       setting: 'ianm-synopsis.excerpt-type',
       options: typeOptions(),
       type: 'select',
+    })
+    .registerSetting({
+      label: app.translator.trans('ianm-synopsis.admin.settings.disable-when-searching.label'),
+      help: app.translator.trans('ianm-synopsis.admin.settings.disable-when-searching.help'),
+      setting: 'ianm-synopsis.disable-when-searching',
+      type: 'switch',
     });
 
   extendEditTagModal();

--- a/js/src/forum/addSummaryExcerpt.tsx
+++ b/js/src/forum/addSummaryExcerpt.tsx
@@ -20,6 +20,10 @@ export default function addSummaryExcerpt() {
   });
 
   extend(DiscussionListItem.prototype, 'infoItems', function (items: ItemList) {
+    // Skip if we are searching to preserve most relevant post content as excerpt,
+    // that way we also preserve highlighting of search terms in the most relevant post.
+    if (app.forum.attribute('synopsis.disable_when_searching') && app.discussions.params.q) return;
+
     const discussion = this.attrs.discussion;
 
     if (app.session.user && !app.session.user.preferences().showSynopsisExcerpts) {

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,13 +1,16 @@
 ianm-synopsis:
   admin:
     settings:
+      disable-when-searching:
+        label: Disable synopsis when searching
+        help: When enabled, the default most relevant post excerpt will be used instead of the synopsis
       excerpt-length:
         label: Summary excerpt length in characters
         help: How many characters should be displayed from the post.
       rich-excerpts:
         label: Display excerpts using rich content
         help: When enabled, images, embeds and other non text elements may be included in the synopsis
-      excerpt-type: 
+      excerpt-type:
         label: Which post should be displayed as the excerpt?
         help: Select if the first or last post be used for synopsis content
       first-label: First post


### PR DESCRIPTION
When this extension is used, most relevant pst content is replaced in search results in the UI. This PR fixes that and adds a setting in case others want to stick with the previous behavior.